### PR TITLE
clone: allow usage as library

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,4 +7,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: ./test
+      - run: ./test.unit
+      - run: ./test.integration

--- a/clone
+++ b/clone
@@ -1,40 +1,50 @@
 #!/bin/bash
-set -eu
 
-if [ "$#" -lt 1 ]; then
-    echo "usage: $(basename "${0}") [git-clone-options] <repository>"
-    exit 1
-fi
-
-url="${@: -1}"
-case ${url} in
-    *://*/*/*)
-        # https://git.sr.ht/~maxmouchet/website
-        # host=git.sr.ht, user=~maxmouchet, repo=website
-        host=$(echo "${url}" | cut -d "/" -f 3)
-        path=$(echo "${url}" | cut -d "/" -f 4-)
-
-        ;;
-    *@*:*/*)
-        # git@github.com:maxmouchet/HMMBase.jl.git
-        # host=github.com, user=maxmouchet, repo=HMMBase.jl.git
-        all=$(echo "${url}" | cut -d "@" -f 2)
-        host=$(echo "${all}" | cut -d ":" -f 1)
-        path=$(echo "${all}" | cut -d ":" -f 2 | cut -d "/" -f 1-)
-
-        ;;
-    *)
-        echo "Unsupported URL: ${url}"
+function clone_main {
+    if [ "$#" -lt 1 ]; then
+        echo "usage: $(basename "${0}") [git-clone-options] <repository>"
         exit 1
-        ;;
-esac
+    fi
 
-basedir=${CLONE_BASE_DIR:-$HOME/Clones}
-path="${path#\~}"
-target="${basedir}/${host}/${path%.git}"
+    local basedir=${CLONE_BASE_DIR:-$HOME/Clones}
+    local path=$(clone_get_path ${@: -1})
+    local target="${basedir}/${path}"
 
-git clone "$@" "${target}"
+    git clone "$@" "${target}"
 
-if command -v autojump > /dev/null; then
-    autojump --add "${target}"
+    if command -v autojump > /dev/null; then
+        autojump --add "${target}"
+    fi
+}
+
+function clone_get_path {
+    local all host path url=$1
+    case ${url} in
+        *://*/*/*)
+            # https://git.sr.ht/~maxmouchet/website
+            # host=git.sr.ht, path=~/maxmouchet/website
+            host=$(echo "${url}" | cut -d "/" -f 3)
+            path=$(echo "${url}" | cut -d "/" -f 4-)
+            ;;
+        *@*:*/*)
+            # git@github.com:maxmouchet/HMMBase.jl.git
+            # host=github.com, path=maxmouchet/HMMBase.jl.git
+            all=$(echo "${url}" | cut -d "@" -f 2)
+            host=$(echo "${all}" | cut -d ":" -f 1)
+            path=$(echo "${all}" | cut -d ":" -f 2 | cut -d "/" -f 1-)
+            ;;
+        *)
+            echo "Unsupported URL: ${url}"
+            exit 1
+            ;;
+    esac
+    path="${path#\~}"
+    path="${path%.git}"
+    echo "${host}/${path}"
+}
+
+if [ "${#BASH_SOURCE[@]}" -eq 1 ]; then
+    set -o errexit
+    set -o nounset
+    clone_main "$@"
 fi

--- a/test.integration
+++ b/test.integration
@@ -5,13 +5,11 @@ export CLONE_BASE_DIR=$(mktemp -d)
 urls=(
     https://github.com/octocat/Hello-World
     https://git.sr.ht/~sircmpwn/git.sr.ht
-    https://gitlab.com/gitlab-org/cells/router
 )
 
 dirs=(
     "$CLONE_BASE_DIR/github.com/octocat/Hello-World"
     "$CLONE_BASE_DIR/git.sr.ht/sircmpwn/git.sr.ht"
-    "$CLONE_BASE_DIR/gitlab.com/gitlab-org/cells/router"
 )
 
 for url in ${urls[@]}; do

--- a/test.unit
+++ b/test.unit
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eu
+source ./clone
+
+declare -A cases
+
+# cases[url]=path
+cases["https://github.com/octocat/Hello-World"]="github.com/octocat/Hello-World"
+cases["https://git.sr.ht/~sircmpwn/git.sr.ht"]="git.sr.ht/sircmpwn/git.sr.ht"
+cases["git@gitlab.com:gitlab-org/cells/router.git"]="gitlab.com/gitlab-org/cells/router"
+
+for url in "${!cases[@]}"; do
+    expected="${cases[$url]}"
+    result="$(clone_get_path $url)"
+    echo "---"
+    echo "url:      $url"
+    echo "result:   $result"
+    echo "expected: $expected"
+    if [[ "$result" != "$expected" ]]; then
+        exit 1
+    fi
+done


### PR DESCRIPTION
- Split code in two functions: `clone_get_path` and `clone_main`
- Run `clone_main` only when not sourced
- Split tests in `test.unit` and `test.integration`
  - Makes it easier to test URLs without actually cloning the repositories